### PR TITLE
v0.2.2

### DIFF
--- a/evm_extras/tools.py
+++ b/evm_extras/tools.py
@@ -85,7 +85,7 @@ def load_contracts(
     path = os.path.join(contracts_path, folder_name)
 
     if version:
-        path = os.path.join(contracts_path, f'v{version}')
+        path = os.path.join(path, f'v{version}')
 
     contract_data = {}
     with open(f"{path}/contracts.json") as file:

--- a/evm_extras/types.py
+++ b/evm_extras/types.py
@@ -1,4 +1,8 @@
+from typing import Literal
+from evm_wallet import ERC20Token
 from web3.contract import AsyncContract, Contract
 from web3.types import ABI
 
 ContractMap = dict[str, AsyncContract | ABI | Contract]
+NativeToken = Literal['AVAX', 'ETH', 'BNB', 'FTM', 'MATIC', '0x0000000000000000000000000000000000000000']
+Token = ERC20Token | NativeToken

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'evm_extras'
-version = '0.2.1'
+version = '0.2.2'
 description = 'The package containing utilities to develop Web3-based projects'
 authors = ['Alexey <abelenkov2006@gmail.com>']
 license = 'MIT'


### PR DESCRIPTION
**Fixing Bugs**:
- If `version` in `load_contracts` was set, there was an issue with path generation
- Adding types `NativeToken` and `Token`