### PR TITLE
v0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [![Croco Logo](https://i.ibb.co/G5Pjt6M/logo.png)](https://t.me/crocofactory)
 
+[![PyPi Version](https://img.shields.io/pypi/v/evm-extras)](https://pypi.org/project/evm-extras/)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/evm-extras?label=downloads)](https://pypi.org/project/evm-extras/)
+[![License](https://img.shields.io/github/license/blnkoff/evm-extras.svg)](https://pypi.org/project/evm-extras/)
+[![Last Commit](https://img.shields.io/github/last-commit/blnkoff/evm-extras.svg)](https://pypi.org/project/evm-extras/)
+[![Development Status](https://img.shields.io/pypi/status/evm-extras)](https://pypi.org/project/evm-extras/)
+
 The package containing utilities to develop Web3-based projects
 
 - **[Telegram channel](https://t.me/crocofactory)**

--- a/evm_extras/__init__.py
+++ b/evm_extras/__init__.py
@@ -9,5 +9,5 @@ The package containing utilities to develop Web3-based projects
 
 from .abc import Defi
 from .tools import validate_token, load_contracts, validate_network, encode_to_bytes32
-from .types import ContractMap
+from .types import ContractMap, Token
 from .exceptions import InvalidToken, InvalidToken, InvalidRoute

--- a/evm_extras/tools.py
+++ b/evm_extras/tools.py
@@ -87,36 +87,24 @@ def load_contracts(
     if version:
         path = os.path.join(path, f'v{version}')
 
-    contract_data = {}
     with open(f"{path}/contracts.json") as file:
         content = json.load(file)
         contract_names = content.keys()
 
-        for name in contract_names:
-            contract_content = content[name]
-            if 'address' in contract_content:
-                addresses = contract_content['address']
-                if network not in addresses:
-                    raise ContractNotFound(defi, network, addresses.keys())
-
-                contract_data[name] = {'address': addresses[network], 'abi_path': contract_content['abi']}
-            else:
-                contract_data[name] = {'abi_path': contract_content['abi']}
-
-    for name in contract_names:
-        with open(os.path.join(path, contract_data[name]['abi_path'])) as file:
-            abi = json.load(file)
-            if name in contract_data:
-                contract_data[name]['abi'] = abi
-            else:
-                contract_data[f"{name}_abi"] = {'abi': abi}
-
     contracts = {}
-    for key, value in contract_data.items():
-        abi = value['abi']
+    for name in contract_names:
+        contract_content = content[name]
+        with open(os.path.join(path, contract_content['abi'])) as file:
+            abi = json.load(file)
 
-        address = value.get('address')
-        contracts[key] = provider.eth.contract(address=address, abi=abi) if address else abi
+        if 'address' in contract_content:
+            addresses = contract_content['address']
+            if network not in addresses:
+                raise ContractNotFound(defi, network, addresses.keys())
+
+            contracts[name] = provider.eth.contract(address=addresses[network], abi=abi)
+        else:
+            contracts[f'{name}_abi'] = abi
 
     return contracts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'evm_extras'
-version = '0.2.2'
+version = '0.2.3'
 description = 'The package containing utilities to develop Web3-based projects'
 authors = ['Alexey <abelenkov2006@gmail.com>']
 license = 'MIT'


### PR DESCRIPTION
**Fixing Bugs**:
- If key in `contracts.json` was related only to abi (without addresses), `load_contracts` generated wrong output key. Right key - `<name>_abi`